### PR TITLE
Corrigir erro Deprecated no PHP 8.1

### DIFF
--- a/src/Collections/AbstractCollection.php
+++ b/src/Collections/AbstractCollection.php
@@ -97,7 +97,7 @@ abstract class AbstractCollection implements Collection
     public function ascending()
     {
         usort($this->collection, function(Holiday $a, Holiday $b) {
-            return $a->{$this->sortField}() > $b->{$this->sortField}();
+            return $a->{$this->sortField}() <=> $b->{$this->sortField}();
         });
 
         return $this;
@@ -109,7 +109,7 @@ abstract class AbstractCollection implements Collection
     public function descending()
     {
         usort($this->collection, function(Holiday $a, Holiday $b) {
-            return $a->{$this->sortField}() < $b->{$this->sortField}();
+            return ($a->{$this->sortField}() <=> $b->{$this->sortField}()) * -1;
         });
 
         return $this;


### PR DESCRIPTION
Quando tenta fazer o sort por `ascending` ou `descending` e está retornando um erro que retornar boolean em um callback de ordenação não é mais permitido. 